### PR TITLE
Add TAC agenda 2020-01-15.

### DIFF
--- a/meetings/2020-01-15.md
+++ b/meetings/2020-01-15.md
@@ -1,0 +1,49 @@
+# AWSF TAC Meeting - Month DD, Year
+
+## Voting member attendance
+
+[ ] Daniel Heckenberg - Chairperson, Animal Logic Pty Ltd
+[ ] Gordon Bradley, Autodesk
+[ ] Pilar Molina Lopez, Blue Sky Studios, Inc.
+[ ] Michael O’Gorman, Cisco Systems Inc.
+[ ] Henry Vera, Double Negative
+[ ] Bill Ballew, DreamWorks Animation
+[ ] Matt Kuhlenschmidt, Epic Games, Inc.
+[ ] Brian Cipriano, Google & OpenCue Representative
+[ ] Sean C McDuffee, Intel Corporation
+[ ] Larry Gritz, Sony Pictures Imageworks
+[ ] Jean-Francois Panisset, VES Technology Committee
+[ ] Cory Omand, The Walt Disney Studios
+[ ] Kimball Thurston, Weta Digital Limited
+[ ] Eric Enderton, NVIDIA
+[ ] Sean Looper, Amazon Web Services
+[ ] Michael Min, Netflix
+[ ] Michael B. Johnson, Apple
+[ ] Dave Fellows, Microsoft
+[ ] Ken Museth, OpenVDB Representative
+[ ] Michael Dolan, OpenColorIO Representative
+[ ] Cary Phillips, OpenEXR Representative
+[ ] Joshua Minor, OpenTimelineIO Representative
+
+# Agenda
+
+- Survey Results & Discussion
+
+- Goals for TAC: Year 2
+
+- Google Summer of Code (Larry)
+
+- CI updates
+  - Working group
+
+- Update on candidate projects
+
+- Next meeting
+  - 29 January 2020
+  
+# Action Items (AIs)
+
+# Notes
+
+# Chat
+


### PR DESCRIPTION
Signed-off-by: Daniel Heckenberg <daniel.heckenberg+github@gmail.com>