### PR TITLE
Update broken CLA links to v2.1

### DIFF
--- a/process/contributing.md
+++ b/process/contributing.md
@@ -104,8 +104,8 @@ The ASWF community is aiming to align around the [ASWF 2020 CCLA template] and [
 
 [Apache License, Version 2.0]: http://www.apache.org/licenses/LICENSE-2.0
 [ASF Contributor Agreements]: https://www.apache.org/licenses/contributor-agreements.html
-[ASWF 2020 CCLA template]: ccla_template_aswf2020.md
-[ASWF 2020 ICLA template]: icla_template_aswf2020.md
+[ASWF 2020 CCLA template]: cla/ccla_template_aswf2020_v2.1.md
+[ASWF 2020 ICLA template]: cla/icla_template_aswf2020_v2.1.md
 [Community Data License Agreement (CDLA) license]: https://cdla.io/
 [Creative Commons Attribution 4.0 International License]: http://creativecommons.org/licenses/by/4.0/
 [Linux Foundation minimal CCLA template]: ccla_template_lfshortform.md


### PR DESCRIPTION
The links were broken, and they referred to the "v2.0" document, not the updated "v3.1"

I'm not sure if you want to refer to "2.1" in the body or leave as is.

Signed-off-by: Cary Phillips <cary@ilm.com>