### PR TITLE
Netlify metadata for GSOC 2022

### DIFF
--- a/gsoc/2022.md
+++ b/gsoc/2022.md
@@ -1,3 +1,6 @@
+---
+parent: Google Summer of Code
+---
 # ASWF Google Summer of Code 2022
 
 The Academy Software Foundation (ASWF) is collaboration between the Linux


### PR DESCRIPTION
Show document under GSOC section of [Netlify version of repo](https://tac.aswf.io/).

Signed-off-by: Jean-Francois Panisset <panisset@gmail.com>