### PR TITLE
Rename project lifecycle stage 'Adopted' to 'Graduated'

### DIFF
--- a/process/lifecycle.md
+++ b/process/lifecycle.md
@@ -24,7 +24,7 @@ This document provides four lifecycle stages for contributed projects:
 
 * Sandbox;
 * Incubation;
-* Adopted; and
+* Graduated; and
 * Archived
 
 Any project to be considered for inclusion by the TAC must complete the [proposal template](proposal_template). More details on bringing a project to the Academy Software Foundation are outlined [here](start_project).
@@ -73,7 +73,7 @@ At the project's [Annual Review](review_cycle), the TAC will vote to either:
 
 * Move the project to the Incubation Stage if it meets the requirements for that stage.
 * Renew the project at the Sandbox Stage if it feels it will move to the Incubation Stage by the next Annual Review.
-* Move the project to the [Archive Stage](#archive-stage). In this case, the trademark and any other assets will be returned to the project maintainers or an organization they designate.
+* Move the project to the [Archived Stage](#Archived-stage). In this case, the trademark and any other assets will be returned to the project maintainers or an organization they designate.
 
 ## Incubation Stage
 
@@ -85,7 +85,7 @@ To be accepted at the Incubation stage, a project must meet the Sandbox requirem
 
 *   Have defined its technical governance, including:
     *   A README file welcoming new community members to the project and explaining why the project is useful and how to get started ( follow the guidelines at the [README checklist](https://github.com/ddbeck/readme-checklist) to create an excellent README file ).
-    *   A CODEOWNERS or COMMITTERS file to define individuals or teams responsible for code in a repository; document current project owners and current and emeritus committers. 
+    *   A CODEOWNERS or COMMITTERS file to define individuals or teams responsible for code in a repository; document current project owners and current and Archived committers. 
     *   A RELEASE file that documents the release methodology, cadence, criteria, etc.
 *   Have achieved and maintained an OpenSSF Best Practices Badge at the [Passing Level](https://bestpractices.coreinfrastructure.org/en/criteria). 
 *   Have a defined project mission and scope
@@ -94,12 +94,12 @@ To be accepted at the Incubation stage, a project must meet the Sandbox requirem
 *   Community and contributor growth assessment
     *   The current number of contributors, committers, and different organizations contributing to the project. 
     *   Demonstrate a sustained flow of commits / merged contributions
-    *   A healthy number of end-users within the visual effects and motion picture industries have adopted the project and are identified by the project ( using an ADOPTERS file or showcased on the project’s website ).
+    *   A healthy number of end-users within the visual effects and motion picture industries have Graduated the project and are identified by the project ( using an ADOPTERS file or showcased on the project’s website ).
     *   A credible plan for developing a thriving user community, particularly expanding the number of committers and contributors?
-    *   Outline of the plan for the project to complete the requirements for the [Adopted Stage](#adopted-stage)
+    *   Outline of the plan for the project to complete the requirements for the [Graduated Stage](#Graduated-stage)
 * Obtain an affirmative vote of the TAC.
 
-Projects preparing to be considered for the Incubation Stage should prepare a presentation outlining how it has completed the requirements and present it at the TAC meeting where it is being considered.
+Projects preparing to be considered for the Incubation Stage should prepare a presentation outlining how they have completed the requirements and present it at the TAC meeting where they are being considered.
 
 ### Benefits
 
@@ -114,23 +114,23 @@ Incubation stage projects are eligible to receive the following benefits:
 
 ### Expectations
 
-During the project's Annual Review, the TAC will assess the progress toward graduating to the Adopted Stage. Projects can also request to hold their annual review early if they have completed the requirements before its scheduled [Annual Review](review_cycle). At the Annual Review, the TAC will vote to either: 
+During the project's Annual Review, the TAC will assess the progress toward graduating to the Graduated Stage. Projects can also request to hold their annual review early if they have completed the requirements before its scheduled [Annual Review](review_cycle). At the Annual Review, the TAC will vote to either: 
 
-* Move the project to the Adopted Stage if it [meets those requirements](#requirements-2).
-* Renew the project at the Incubation Stage if it feels it will move to the Adopted Stage by the next Annual Review.
-* Move the project to the [Archive Stage](#archive-stage). In this case, the trademark and any other assets will be returned to the project maintainers or an organization they designate.
+* Move the project to the Graduated Stage if it [meets those requirements](#requirements-2).
+* Renew the project at the Incubation Stage if it feels it will move to the Graduated Stage by the next Annual Review.
+* Move the project to the [Archived Stage](#Archived-stage). In this case, the trademark and any other assets will be returned to the project maintainers or an organization they designate.
 
-## Adopted Stage
+## Graduated Stage
 
-Adopted Stage projects are considered mature projects that generally are ready for production use. Projects at this stage focus on growing an ecosystem of users and are often being leveraged in vendor products or used by end-users.
+Graduated Stage projects have matured open source project processes and procedures that are aligned with the best practices defined by the OpenSSF and the industry at large. Projects at this stage focus on growing an ecosystem of users and are often leveraged in vendor products or used by end-users.
 
 ### Requirements
 
-To be considered for the Adopted stage, a project must meet the Incubation stage requirements plus:
+To be considered for the Graduated stage, a project must meet the Incubation stage requirements plus:
 
 * Demonstrate a substantial ongoing flow of commits and merged contributions authored by a healthy number of diverse contributors*.
 * Demonstrable roadmap progress.
-* A significant number of end-users within the visual effects and motion picture industries that have adopted the project and that are identified within the project ( using an ADOPTERS file or showcased on the project’s website ).
+* A significant number of end-users within the visual effects and motion picture industries have adopted the project and are identified within the project ( using an ADOPTERS file or showcased on the project’s website ).
 * Have completed all of the OpenSSF Best Practices Badge requirements at the [gold level](https://bestpractices.coreinfrastructure.org/en/criteria/2), except for the following criteria, which are temporarily not required:
   * [The project MUST have performed a security review within the last 5 years. This review MUST consider the security requirements and security boundary](https://www.bestpractices.dev/en/criteria?details=true&rationale=true#2.security_review)
   * [The project MUST provide an assurance case that justifies why its security requirements are met. The assurance case MUST include: a description of the threat model, clear identification of trust boundaries, an argument that secure design principles have been applied, and an argument that common implementation security weaknesses have been countered.](https://www.bestpractices.dev/en/criteria?details=true&rationale=true#1.assurance_case)
@@ -142,39 +142,39 @@ To be considered for the Adopted stage, a project must meet the Incubation stage
   * [The project (both project sites and project results) SHOULD follow accessibility best practices so that persons with disabilities can still participate in the project and use the project results where it is reasonable to do so.](https://www.bestpractices.dev/en/criteria?details=true&rationale=true#1.accessibility_best_practices)
   * [The project MUST list external dependencies in a computer-processable way.](https://www.bestpractices.dev/en/criteria?details=true&rationale=true#1.external_dependencies)
   * [The project results MUST check all inputs from potentially untrusted sources to ensure they are valid (an allowlist), and reject invalid inputs, if there are any restrictions on the data at all.](https://www.bestpractices.dev/en/criteria?details=true&rationale=true#1.input_validation)
-* Have a technical lead appointed for voting representation of the project to the TAC.
+* Have a technical lead appointed as a voting representative of the project to the TAC.
 * Be deemed by the TAC to add value to the mission of the Academy Software Foundation.
 * Obtain both a 2/3 supermajority vote of the TAC and an affirmative majority vote of the Governing Board
 
-*Since these metrics can vary significantly depending on a project's type, scope, and size, the TAC has final judgment over the level of activity adequate to meet these criteria. In general, it will be necessary to (at least) demonstrate that the project is not overly reliant on any one individual or organization and can remain healthy in the event of a departure.
+*Since these metrics can vary significantly depending on a project's type, scope, and size, the TAC has final judgment over the activity level adequate to meet these criteria. In general, it will be necessary to (at least) demonstrate that the project is not overly reliant on any one individual or organization and can remain healthy in the event of a departure.
 
 ### Benefits
 
-Adopted stage projects are eligible to receive the following benefits:
+Graduated stage projects are eligible to receive the following benefits:
 
 * Be considered as one of the “TAC Projects” under the [Academy Software Foundation Charter](https://github.com/AcademySoftwareFoundation/foundation/blob/master/CHARTER.md) and may receive additional resources or support as determined by the Governing Board.
 * Have a voting representative on the TAC.
-* Right to refer to the project as an officially adopted project of the Academy Software Foundation and receive the highest priority for participating in events and other collaborative activities sponsored by the Academy Software Foundation.
+* Right to refer to the project as an officially Graduated project of the Academy Software Foundation and receive the highest priority for participating in events and other collaborative activities sponsored by the Academy Software Foundation.
 * A blog announcement or similar communication announcing the graduation of the project.
 
 ### Expectations
 
-Adopted Stage projects will have an Annual Review to assess if the project is still meeting the Adopted Stage requirements. At the Annual Review, the TAC will vote to either: 
+Graduated Stage projects will have an Annual Review to assess if the project is still meeting the Graduated Stage requirements. At the Annual Review, the TAC will vote to either: 
 
-* Renew the project at the Adopted Stage if it continues to [meet those requirements](#requirements-2).
-* Move the project to the [Archive Stage](#archive-stage). In this case, the trademark and any other assets will be returned to the project maintainers or an organization they designate.
+* Renew the project at the Graduated Stage if it continues to [meet those requirements](#requirements-2).
+* Move the project to the [Archived Stage](#Archived-stage). In this case, the trademark and any other assets will be returned to the project maintainers or an organization they designate.
 
-For the first Annual Review after the project reaches the Adopted Stage, it is expected that the project has completed 100% of the OpenSSF Best Practices Badge requirements at the [gold level](https://bestpractices.coreinfrastructure.org/en/criteria/2) with the exception of the requirements listed above.
+For the first Annual Review after the project reaches the Graduated Stage, it is expected that the project has completed 100% of the OpenSSF Best Practices Badge requirements at the [gold level](https://bestpractices.coreinfrastructure.org/en/criteria/2) with the exception of the requirements listed above.
 
-## Archive Stage
+## Archived Stage
 
-Projects like products have lifecycles, and often, in open source, the relevance of a given project can diminish over time. Nonetheless, having a home for legacy and no longer maintained projects within the industry is crucial for long-term sustainability and asset management. Projects with operational, contributor, and/or adoption issues are not necessarily candidates for the Archive Stage; the TAC will work with these projects to improve any of these issues.
+Projects like products have lifecycles, and often, in open source, the relevance of a given project can diminish over time. Nonetheless, having a home for legacy and no longer maintained projects within the industry is crucial for long-term sustainability and asset management. Projects with operational, contributor, and/or adoption issues are not necessarily candidates for the Archived Stage; the TAC will work with these projects to improve any of these issues.
 
-Projects can only enter the Archive Stage by either:
+Projects can only enter the Archived Stage by either:
 
 *   On request from the project itself, a 2/3 supermajority vote of all active project committers is required.
 *   By a 2/3 supermajority vote of the TAC if deemed to be no longer maintained.
 
-In the Archive Stage, the TAC transfers the project’s code repository administration to a designated individual. No new features or bug fixes will be addressed unless they are deemed security issues. Academy Software Foundation will hold all assets in perpetuity. Archive stage projects will be considered “Technical Projects" under the Academy Software Foundation charter and may receive support as determined by the Governing Board.
+In the Archived Stage, the TAC transfers the project’s code repository administration to a designated individual. No new features or bug fixes will be addressed unless they are deemed security issues. Academy Software Foundation will hold all assets in perpetuity. Archived Stage projects will be considered “Technical Projects" under the Academy Software Foundation charter and may receive support as determined by the Governing Board.
 
-A project can move back to one of the Sandbox, Incubation, or Adopted Stages following the guidelines for a project being accepted at that level.
+A project can move back to one of the Sandbox, Incubation, or Graduated Stages following the guidelines for a project being accepted at that level.


### PR DESCRIPTION
This has been a discussion topic for some time, so it likely makes sense to codify this.

Two reasons for this change:

- The term 'Adopted' ends up being a misnomer, making it seem that projects like OTIO or OIIO that have been used for eons by the industry aren't/shouldn't be adopted. The TAC lifecycle views maturity in terms of open source best practices and infrastructure ( which can be a leading indicator of adoption, but not a direct correlation ) 
- 'Graduated' is a more common term used in other project lifecycles, so this helps align expectations across ecosystems.

Please review/discuss. I've also changed the 'Graduated' stage description to clarify it better. I also fixed a few sentences as Grammarly thought I should :)