### PR TITLE
Enhance DCO section in contributing guidelines

### DIFF
--- a/process/contributing.md
+++ b/process/contributing.md
@@ -53,13 +53,23 @@ Assumes [Apache License, Version 2.0][] and Foo project name.
 
 Ensuring a clean code pedigree and lineage is critical to the industry's downstream adoption of open-source code.
 
-Academy Software Foundation requires the use of the [Developer’s Certificate of Origin 1.1 (DCO)][DCO], which is the same mechanism that the [Linux® Kernel](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/Documentation/process/submitting-patches.rst#n416) and many other communities use to manage code contributions. The DCO is considered one of the simplest tools for sign-offs from contributors as the representations are meant to be easy to read and indicate signoff is done as a part of the commit message.
+Academy Software Foundation requires the use of the [Developer’s Certificate of Origin 1.1 (DCO)][DCO], which is the same mechanism that the [Linux® Kernel](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/Documentation/process/submitting-patches.rst#n416) and many other communities use to manage code contributions. The DCO is considered one of the simplest tools for sign-offs from contributors as the representations are meant to be easy to read and indicate signoff is done as a part of the commit message. The DCO is a representation by someone stating they have the right to contribute the code they have proposed for acceptance into a project.  That representation is important for legal purposes and was the community-developed outcome after a $1 billion [lawsuit](https://en.wikipedia.org/wiki/SCO%E2%80%93Linux_disputes) by SCO against IBM. The representation is designed to prevent issues but also keep the burden on contributors low. It has proven very adaptable to other projects, is built into git itself (and now also GitHub), and is in use by thousands of projects to avoid more burdensome requirements to contribute (such as a CLA).
 
 Here is an example Signed-off-by line, which indicates that the submitter accepts the DCO:
 
 `Signed-off-by: John Doe <john.doe@example.com>`
 
 You can include this automatically when you commit a change to your local git repository using <code>git commit -s</code>.
+
+### DCO and Real Names
+
+The DCO requires the use of a real name that can be used to identify someone in case there is an issue about a contribution they made. 
+
+**A real name does not require a legal name, nor a birth name, nor any name that appears on an official ID (e.g. a passport). Your real name is the name you convey to people in the community for them to use to identify you as you. The key concern is that your identification is sufficient enough to contact you if an issue were to arise in the future about your contribution.**
+
+Your real name should not be an anonymous id or false name that misrepresents who you are.
+
+More context can be found at https://github.com/cncf/foundation/issues/383.
 
 ### Make doing DCO signoffs easier
 


### PR DESCRIPTION
Expanded the section on the Developer’s Certificate of Origin (DCO) to clarify its importance, legal implications, and requirements for using real names.