### PR TITLE
Fix link to contribution guidelines in github.md

### DIFF
--- a/tools/github.md
+++ b/tools/github.md
@@ -20,7 +20,7 @@ When a new project or repository is to be added, please [submit a request](https
 If adding the new project or repository will include a significant contribution, requesting a code license scan is highly recommended before bringing the code in. This scan will look for and will provide recommendations (or, in some cases, required prior remediation) for:
 
 - The presence of third-party licenses (OSI-approved or otherwise) that might be considered incompatible with the project's license
-- Presence of headers with the project's designated license(s) and preferred copyright notices in project files (refer to the [License Specification in the Contribution Guidelines]({% link process/contribution_guidelines.md %}#license-specification) for more information)
+- Presence of headers with the project's designated license(s) and preferred copyright notices in project files (refer to the [License Specification in the Contribution Guidelines]({% link process/contributing.md %}#license-specification) for more information)
 - Any other best practices guidance
 
 Projects can [submit a request]({{ site.helpdesk_url }}) to facilitate the process. Typically code license scans are a quick turnaround, but that might take longer for more significant code bases.


### PR DESCRIPTION
Updated link in the code license scan section to point to the correct contribution guidelines.