### PR TITLE
Update DCO Checker script link

### DIFF
--- a/process/contributing.md
+++ b/process/contributing.md
@@ -103,7 +103,7 @@ The following commits were made pursuant to the Developer Certificate of Origin,
 
 Each user who has made the past commits should have their own <code>Signed-off-by:</code> line in the commit message.
 
-This process can be automated using the [DCO Org Check script](https://github.com/jmertic/dco-org-check).
+This process can be automated using the [Contribution Checker script](https://github.com/jmertic/contrib_check).
 
 ### Handling DCO errors using GitHub website commits.
 


### PR DESCRIPTION
Updates the DCO Checker script link on the Contribution Guidelines page. The old repo link has been deprecated in favor of the newer repository.